### PR TITLE
Hotfix/update urls

### DIFF
--- a/hermes/urls.py
+++ b/hermes/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns, url
+from django.urls import re_path
 
 from .views import (
     ArchivePostListView,
@@ -9,50 +9,49 @@ from .views import (
 )
 from .feeds import LatestPostFeed
 
-urlpatterns = patterns(
-    '',
-    url(
+urlpatterns = [
+    re_path(
         regex=r'^(?P<year>\d+)/(?P<month>\d+)/(?P<day>\d+)/(?P<slug>[\w-]+)/$',
         view=PostDetail.as_view(),
         name='hermes_post_detail',
     ),
 
-    url(
+    re_path(
         regex=r'^(?P<year>\d+)/(?P<month>\d+)/(?P<day>\d+)/$',
         view=ArchivePostListView.as_view(),
         name='hermes_archive_year_month_day',
     ),
 
-    url(
+    re_path(
         regex=r'^(?P<year>\d+)/(?P<month>\d+)/$',
         view=ArchivePostListView.as_view(),
         name='hermes_archive_year_month',
     ),
 
-    url(
+    re_path(
         regex=r'^(?P<year>\d+)/$',
         view=ArchivePostListView.as_view(),
         name='hermes_archive_year',
     ),
 
-    url(
+    re_path(
         regex=r'categories/(?P<slug>.+)/$',
         view=CategoryPostListView.as_view(),
         name='hermes_category_post_list',
     ),
 
-    url(
+    re_path(
         regex=r'authors/(?P<author>.+)/$',
         view=AuthorPostListView.as_view(),
         name='hermes_author_post_list',
     ),
 
-    url(
+    re_path(
         regex=r'^$',
         view=PostListView.as_view(),
         name='hermes_post_list',
     ),
-    url(
+    re_path(
         regex=r'^feed/$',
         view=LatestPostFeed(),
         name='hermes_post_feed'


### PR DESCRIPTION
This work implements `re_path` in place of `url` which has been deprecated in Django 3.1. 

https://docs.djangoproject.com/en/3.1/ref/urls/